### PR TITLE
feat[#13] 게시글 삭제 API 구현

### DIFF
--- a/src/main/java/com/lol/community/board/controller/BoardApiController.java
+++ b/src/main/java/com/lol/community/board/controller/BoardApiController.java
@@ -45,4 +45,11 @@ public class BoardApiController {
         Board board = boardService.modify(id, request);
         return ResponseEntity.ok(board.toResponse());
     }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "게시글 삭제", description = "게시글 ID 기반의 게시글 삭제")
+    public ResponseEntity<Void> deleteArticle(@PathVariable("id") Integer id) {
+        boardService.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/lol/community/board/service/BoardService.java
+++ b/src/main/java/com/lol/community/board/service/BoardService.java
@@ -31,4 +31,9 @@ public class BoardService {
         board.update(request);
         return board;
     }
+
+    public void deleteById(Integer id) {
+        Board board = findById(id);
+        boardRepository.delete(board);
+    }
 }

--- a/src/test/java/com/lol/community/board/controller/BoardApiControllerTest.java
+++ b/src/test/java/com/lol/community/board/controller/BoardApiControllerTest.java
@@ -22,11 +22,11 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -132,5 +132,29 @@ class BoardApiControllerTest {
                 .orElseThrow(IllegalAccessException::new);
 
         assertEquals(board, updated);
+    }
+
+    @Test
+    void 게시글_삭제_통합_테스트() throws Exception {
+        //given
+        Board board = Board.builder()
+                .id(1)
+                .user(new User(1))
+                .category(new Category(2))
+                .boardType(BoardType.REPORT.name())
+                .title("title")
+                .content("content")
+                .build();
+
+        when(boardRepository.save(any())).thenReturn(board);
+        when(boardRepository.findById(anyInt())).thenReturn(Optional.of(board));
+        Integer id = boardRepository.save(board).getId();
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete("/api/board/{id}", id));
+
+        //then
+        resultActions.andExpect(status().isOk());
+        assertFalse(boardRepository.existsById(id));
     }
 }


### PR DESCRIPTION
## 작업 사항 📝
- 세션 기반의 로그인 기능 구현 
- 테스트 코드 기반 및 실제 DB 테스트 진행 

## 참고 사항 🔨
- 단순 게시글 삭제 관련 API 구현과 테스트 코드 작성했습니다. 
- 추후 파일 삭제에 대한 DB 테이블 변경 및 서버 내 파일 삭제 예정입니다. 
- 댓글에 대한 삭제 기능도 일단은 미 포함했습니다. 
- 정리되는 대로 추가 예정 

참고 부탁드립니다.  @ecruosnepo 

## 관련 이슈 🎯
- #13 
